### PR TITLE
Finish wiring up multiple return values using "BlockData" objects

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Build
       run: dotnet build -p:Version=${{ env.buildVersion }} -p:ContinuousIntegrationBuild=True --no-restore --configuration Release
     - name: Test
-      run: dotnet test --no-build --configuration Release --verbosity normal
+      run: dotnet test --filter FullyQualifiedName!~ExampleTests --no-build --configuration Release --verbosity normal
     - name: Pack
       if: startsWith(github.ref, 'refs/tags/v')
       run: dotnet pack -p:PackageVersion=${{ env.nugetVersion }} --configuration Release -o ${{github.workspace}}/IntelliTect.SelenatePack --no-build 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET

--- a/IntelliTect.TestTools.TestFramework.Tests/TestCaseTests/MultipleDependencyTests.cs
+++ b/IntelliTect.TestTools.TestFramework.Tests/TestCaseTests/MultipleDependencyTests.cs
@@ -1,10 +1,11 @@
-﻿using IntelliTect.TestTools.TestFramework.Tests.TestData.Dependencies;
-using IntelliTect.TestTools.TestFramework.Tests.TestData.TestBlocks;
+﻿using IntelliTect.TestTools.TestFramework.Tests.TestData.TestBlocks;
+using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace IntelliTect.TestTools.TestFramework.Tests.TestCaseTests
 {
-    public class MultipleDependencyTests
+    public class MultipleDependencyTests : TestBase
     {
         [Fact]
         public void ReturnDuplicateTypesDoesNotThrow()
@@ -37,6 +38,43 @@ namespace IntelliTect.TestTools.TestFramework.Tests.TestCaseTests
 
             // Assert
             Assert.True(tc.Passed);
+        }
+
+        [Fact]
+        public async Task ReturnMultipleObjectsStoresEachObjectSeparately()
+        {
+            // Arrange
+            TestCase tc = new TestBuilder()
+                .AddTestBlock<ExampleBlockWithMultipleReturns>(true)
+                .AddTestBlock<ExampleTestBlockWithExecuteArg>()
+                .AddTestBlock<ExampleTestBlockWithBoolReturn>()
+                .Build();
+
+            // Act
+            await tc.ExecuteAsync();
+
+            // Assert
+            Assert.True(tc.Passed);
+        }
+
+        [Fact]
+        public async Task ReturnMultipleObjectsExecutesSubsequentTestBlocks()
+        {
+            // Arrange
+
+            TestCase tc = new TestBuilder()
+                .AddTestBlock<ExampleBlockWithMultipleReturns>(false)
+                .AddTestBlock<ExampleTestBlockWithExecuteArg>()
+                .AddTestBlock<ExampleTestBlockWithBoolReturn>()
+                .Build();
+
+            // Act
+            var result = await Assert.ThrowsAsync<TestCaseException>(tc.ExecuteAsync);
+
+            // Assert
+            Assert.False(tc.Passed);
+            Assert.NotNull(result.InnerException);
+            Assert.True(result.InnerException.GetType() == typeof(DivideByZeroException));
         }
     }
 }

--- a/IntelliTect.TestTools.TestFramework.Tests/TestData/TestBlocks/MultipleDependencyBlocks.cs
+++ b/IntelliTect.TestTools.TestFramework.Tests/TestData/TestBlocks/MultipleDependencyBlocks.cs
@@ -21,4 +21,12 @@ namespace IntelliTect.TestTools.TestFramework.Tests.TestData.TestBlocks
             Assert.Equal(1234, inputNumber);
         }
     }
+
+    public class ExampleBlockWithMultipleReturns : TestBlock
+    {
+        public BlockData<string, bool> Execute(bool returnValue)
+        {
+            return new BlockData<string, bool>("Testing", returnValue);
+        }
+    }
 }

--- a/IntelliTect.TestTools.TestFramework.Tests/TestDataTests.cs
+++ b/IntelliTect.TestTools.TestFramework.Tests/TestDataTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Xunit;
+
+namespace IntelliTect.TestTools.TestFramework.Tests;
+
+public class TestDataTests
+{
+    [Fact]
+    public void BlockDataT1T2ThrowsExceptionOnDuplicateTypes()
+    {
+        var exception = Assert.Throws<TypeInitializationException>(() => 
+        {
+            var _ = new BlockData<int, int>(1, 2);
+        });
+        Assert.NotNull(exception.InnerException);
+        Assert.Equal(typeof(InvalidOperationException), exception.InnerException.GetType());
+        Assert.Equal("Duplicate type found: Int32 appears multiple times. BlockData must use different types to avoid unexpected behavior by the TestCase DI Container.",
+            exception.InnerException.Message);
+    }
+
+    [Fact]
+    public void BlockDataT1T2T3ThrowsExceptionOnDuplicateTypes()
+    {
+        var exception = Assert.Throws<TypeInitializationException>(() =>
+        {
+            var _ = new BlockData<int, bool, int>(1, true, 2);
+        });
+        Assert.NotNull(exception.InnerException);
+        Assert.Equal(typeof(InvalidOperationException), exception.InnerException.GetType());
+        Assert.Equal("Duplicate type found: Int32 appears multiple times. BlockData must use different types to avoid unexpected behavior by the TestCase DI Container.",
+            exception.InnerException.Message);
+    }
+
+    [Fact]
+    public void BlockDataT1T2T3T4ThrowsExceptionOnDuplicateTypes()
+    {
+        var exception = Assert.Throws<TypeInitializationException>(() =>
+        {
+            var _ = new BlockData<bool, double, int, int>(false, 0.5, 1, 2);
+        });
+        Assert.NotNull(exception.InnerException);
+        Assert.Equal(typeof(InvalidOperationException), exception.InnerException.GetType());
+        Assert.Equal("Duplicate type found: Int32 appears multiple times. BlockData must use different types to avoid unexpected behavior by the TestCase DI Container.",
+            exception.InnerException.Message);
+    }
+
+    [Fact]
+    public void BlockDataT1T2DoesNotThrowExceptionOnWithUniqueTypes()
+    {
+        BlockData<int, bool> blockData = new(1, true);
+        Assert.Equal(2, blockData.Data.Count);
+    }
+
+    [Fact]
+    public void BlockDataT1T2T3DoesNotThrowExceptionOnWithUniqueTypes()
+    {
+        BlockData<ArgumentException, Exception, bool> blockData = new(new ArgumentException(), new Exception(), true);
+        Assert.Equal(3, blockData.Data.Count);
+    }
+
+    [Fact]
+    public void BlockDataT1T2T3T4DoesNotThrowExceptionOnWithUniqueTypes()
+    {
+        BlockData<int, bool, string, double> blockData = new(1, true, "", 0.5);
+        Assert.Equal(4, blockData.Data.Count);
+    }
+}

--- a/IntelliTect.TestTools.TestFramework.Tests/TestDataTests.cs
+++ b/IntelliTect.TestTools.TestFramework.Tests/TestDataTests.cs
@@ -43,23 +43,29 @@ public class TestDataTests
     }
 
     [Fact]
-    public void BlockDataT1T2DoesNotThrowExceptionOnWithUniqueTypes()
+    public void BlockDataT1T2DoesNotThrowExceptionWithUniqueTypes()
     {
         BlockData<int, bool> blockData = new(1, true);
-        Assert.Equal(2, blockData.Data.Count);
+        Assert.Equal(1, blockData.Data1);
+        Assert.True(blockData.Data2);
     }
 
     [Fact]
-    public void BlockDataT1T2T3DoesNotThrowExceptionOnWithUniqueTypes()
+    public void BlockDataT1T2T3DoesNotThrowExceptionWithUniqueTypes()
     {
         BlockData<ArgumentException, Exception, bool> blockData = new(new ArgumentException(), new Exception(), true);
-        Assert.Equal(3, blockData.Data.Count);
+        Assert.IsType<ArgumentException>(blockData.Data1);
+        Assert.IsType<Exception>(blockData.Data2);
+        Assert.True(blockData.Data3);
     }
 
     [Fact]
-    public void BlockDataT1T2T3T4DoesNotThrowExceptionOnWithUniqueTypes()
+    public void BlockDataT1T2T3T4DoesNotThrowExceptionWithUniqueTypes()
     {
         BlockData<int, bool, string, double> blockData = new(1, true, "", 0.5);
-        Assert.Equal(4, blockData.Data.Count);
+        Assert.Equal(1, blockData.Data1);
+        Assert.True(blockData.Data2);
+        Assert.Equal("", blockData.Data3);
+        Assert.Equal(0.5, blockData.Data4);
     }
 }

--- a/IntelliTect.TestTools.TestFramework/BlockData.cs
+++ b/IntelliTect.TestTools.TestFramework/BlockData.cs
@@ -19,7 +19,7 @@ public class BlockData<T1, T2>(T1 data1, T2 data2) : IBlockData
     public T2 Data2 => data2;
     
 
-    IBlockData.List<KeyValuePair<Type, object?>> Data { get; } = 
+    List<KeyValuePair<Type, object?>> IBlockData.Data { get; } = 
     [
         new KeyValuePair<Type, object?>(typeof(T1), data1),
         new KeyValuePair<Type, object?>(typeof(T2), data2)
@@ -33,7 +33,11 @@ public class BlockData<T1, T2, T3>(T1 data1, T2 data2, T3 data3) : IBlockData
         ValidateData.ValidateUniqueTypes(typeof(T1), typeof(T2), typeof(T3));
     }
 
-    public List<KeyValuePair<Type, object?>> Data { get; } =
+    public T1 Data1 => data1;
+    public T2 Data2 => data2;
+    public T3 Data3 => data3;
+
+    List<KeyValuePair<Type, object?>> IBlockData.Data { get; } =
     [
         new KeyValuePair<Type, object?>(typeof(T1), data1),
         new KeyValuePair<Type, object?>(typeof(T2), data2),
@@ -48,7 +52,12 @@ public class BlockData<T1, T2, T3, T4>(T1 data1, T2 data2, T3 data3, T4 data4) :
         ValidateData.ValidateUniqueTypes(typeof(T1), typeof(T2), typeof(T3), typeof(T4));
     }
 
-    public List<KeyValuePair<Type, object?>> Data { get; } =
+    public T1 Data1 => data1;
+    public T2 Data2 => data2;
+    public T3 Data3 => data3;
+    public T4 Data4 => data4;
+
+    List<KeyValuePair<Type, object?>> IBlockData.Data { get; } =
     [
         new KeyValuePair<Type, object?>(typeof(T1), data1),
         new KeyValuePair<Type, object?>(typeof(T2), data2),

--- a/IntelliTect.TestTools.TestFramework/BlockData.cs
+++ b/IntelliTect.TestTools.TestFramework/BlockData.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace IntelliTect.TestTools.TestFramework;
+
+public interface IBlockData
+{
+    public List<KeyValuePair<Type, object?>> Data { get; }
+}
+
+public class BlockData<T1, T2>(T1 data1, T2 data2) : IBlockData
+{
+    static BlockData()
+    {
+        ValidateData.ValidateUniqueTypes(typeof(T1), typeof(T2));
+    }
+
+    public List<KeyValuePair<Type, object?>> Data { get; } = 
+    [
+        new KeyValuePair<Type, object?>(typeof(T1), data1),
+        new KeyValuePair<Type, object?>(typeof(T2), data2)
+    ];
+}
+
+public class BlockData<T1, T2, T3>(T1 data1, T2 data2, T3 data3) : IBlockData
+{
+    static BlockData()
+    {
+        ValidateData.ValidateUniqueTypes(typeof(T1), typeof(T2), typeof(T3));
+    }
+
+    public List<KeyValuePair<Type, object?>> Data { get; } =
+    [
+        new KeyValuePair<Type, object?>(typeof(T1), data1),
+        new KeyValuePair<Type, object?>(typeof(T2), data2),
+        new KeyValuePair<Type, object?>(typeof(T3), data3)
+    ];
+}
+
+public class BlockData<T1, T2, T3, T4>(T1 data1, T2 data2, T3 data3, T4 data4) : IBlockData
+{
+    static BlockData()
+    {
+        ValidateData.ValidateUniqueTypes(typeof(T1), typeof(T2), typeof(T3), typeof(T4));
+    }
+
+    public List<KeyValuePair<Type, object?>> Data { get; } =
+    [
+        new KeyValuePair<Type, object?>(typeof(T1), data1),
+        new KeyValuePair<Type, object?>(typeof(T2), data2),
+        new KeyValuePair<Type, object?>(typeof(T3), data3),
+        new KeyValuePair<Type, object?>(typeof(T4), data4)
+    ];
+}
+
+internal static class  ValidateData
+{
+    internal static void ValidateUniqueTypes(params Type[] types)
+    {
+        HashSet<Type> seenTypes = [];
+        foreach(Type type in types)
+        {
+            if (!seenTypes.Add(type))
+            {
+                throw new InvalidOperationException($"Duplicate type found: {type.Name} appears multiple times. BlockData must use different types to avoid unexpected behavior by the TestCase DI Container.");
+            }
+        }
+    }
+}

--- a/IntelliTect.TestTools.TestFramework/TestBuilder.cs
+++ b/IntelliTect.TestTools.TestFramework/TestBuilder.cs
@@ -354,7 +354,18 @@ namespace IntelliTect.TestTools.TestFramework
 
             if (executeReturns != typeof(void))
             {
-                outputs.Add(executeReturns);
+                if (executeReturns.GetInterfaces().Any(x => x == typeof(IBlockData)))
+                {
+                    Type[] blockData = executeReturns.GenericTypeArguments;
+                    foreach (Type bd in blockData)
+                    {
+                        outputs.Add(bd);
+                    }
+                }
+                else
+                {
+                    outputs.Add(executeReturns);
+                }
             }
         }
 

--- a/IntelliTect.TestTools.TestFramework/TestCase.cs
+++ b/IntelliTect.TestTools.TestFramework/TestCase.cs
@@ -141,7 +141,7 @@ namespace IntelliTect.TestTools.TestFramework
             {
                 throw new TestCaseException("Test case failed.", TestBlockException);
             }
-            else if(TestBlockException is not null
+            else if (TestBlockException is not null
                 && ThrowOnFinallyBlockException
                 && FinallyBlockExceptions.Any())
             {
@@ -149,7 +149,7 @@ namespace IntelliTect.TestTools.TestFramework
                 throw new AggregateException("Test case failed and finally blocks failed.",
                     FinallyBlockExceptions);
             }
-            else if(TestBlockException is null
+            else if (TestBlockException is null
                 && ThrowOnFinallyBlockException
                 && FinallyBlockExceptions.Any())
             {
@@ -198,7 +198,7 @@ namespace IntelliTect.TestTools.TestFramework
                 _ = TryBuildBlock(scope, block, out foundBlock);
             }
 
-            if(foundBlock is not null)
+            if (foundBlock is not null)
             {
                 blockInstance = foundBlock;
                 result = true;
@@ -232,7 +232,7 @@ namespace IntelliTect.TestTools.TestFramework
                 object? obj = ActivateObject(scope, block, c.ParameterType, "constructor argument");
                 if (obj is null)
                 {
-                    if(!CheckForITestLogger(c.ParameterType))
+                    if (!CheckForITestLogger(c.ParameterType))
                     {
                         blockInstance = null;
                         return false;
@@ -266,7 +266,7 @@ namespace IntelliTect.TestTools.TestFramework
                 object? obj = ActivateObject(scope, block, prop.PropertyType, "property");
                 if (obj is null)
                 {
-                    if(CheckForITestLogger(prop.PropertyType))
+                    if (CheckForITestLogger(prop.PropertyType))
                     {
                         continue;
                     }
@@ -287,12 +287,12 @@ namespace IntelliTect.TestTools.TestFramework
             foreach (ParameterInfo? ep in block.ExecuteParams)
             {
                 object? obj = null;
-                if(block.ExecuteArgumentOverrides.Count > 0)
+                if (block.ExecuteArgumentOverrides.Count > 0)
                 {
                     block.ExecuteArgumentOverrides.TryGetValue(ep.ParameterType, out obj);
                 }
 
-                if(obj is null)
+                if (obj is null)
                 {
                     obj = ActivateObject(scope, block, ep.ParameterType, "execute method argument");
                     if (obj is null)
@@ -324,9 +324,9 @@ namespace IntelliTect.TestTools.TestFramework
                     // Is the below check worth it?
                     // It is avoided if the test block asks for an interface if the dependency is implementing an interface.
                     // HOWEVER, this would facilitate injecting multiple different implementations in a test.
-                    if(obj is null)
+                    if (obj is null)
                     {
-                        foreach(var i in objectType.GetInterfaces())
+                        foreach (var i in objectType.GetInterfaces())
                         {
                             IEnumerable<object?> objs = scope.ServiceProvider.GetServices(i);
                             obj = objs.FirstOrDefault(o => o?.GetType() == objectType);
@@ -379,7 +379,7 @@ namespace IntelliTect.TestTools.TestFramework
                 {
                     dynamic asyncOutput = block.ExecuteMethod.Invoke(blockInstance, executeArgs.ToArray());
                     await asyncOutput;
-                    if(block.AsyncReturnType != typeof(void))
+                    if (block.AsyncReturnType != typeof(void))
                     {
                         output = asyncOutput.GetAwaiter().GetResult();
                     }
@@ -388,12 +388,27 @@ namespace IntelliTect.TestTools.TestFramework
                 {
                     output = block.ExecuteMethod.Invoke(blockInstance, executeArgs.ToArray());
                 }
-                
+
                 if (output is not null)
                 {
-                    Log?.TestBlockOutput(output);
-                    BlockOutput.Remove(output.GetType());
-                    BlockOutput.Add(output.GetType(), output);
+                    if (output is IBlockData blockData)
+                    {
+                        foreach (KeyValuePair<Type, object?> dataPoint in blockData.Data)
+                        {
+                            if (dataPoint.Value is not null)
+                            {
+                                Log?.TestBlockOutput(dataPoint.Value);
+                                BlockOutput.Remove(dataPoint.Key);
+                                BlockOutput.Add(dataPoint.Key, dataPoint.Value);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        Log?.TestBlockOutput(output);
+                        BlockOutput.Remove(output.GetType());
+                        BlockOutput.Add(output.GetType(), output);
+                    }
                 }
                 result = true;
             }


### PR DESCRIPTION
## Description

Add support for a way for a test block to return multiple points of test data. Leverages a new IBlockData interface and three basic implementations (IBlockData<T1,T2 and T3, T4>).

NOTE: It is very possible, though not advised, to do other implementations without generic type arguments, as that circumvents a lot of the pre-execution checking that occurs to make sure top-level dependencies are all being satisfied.

### Ensure that your pull request has followed all the steps below:
- [x] Code compilation
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
