### PR TITLE
Fix async finally block bug

### DIFF
--- a/IntelliTect.TestTools.TestFramework.Tests/TestCaseTests/FinallyExecutionTests.cs
+++ b/IntelliTect.TestTools.TestFramework.Tests/TestCaseTests/FinallyExecutionTests.cs
@@ -8,6 +8,22 @@ namespace IntelliTect.TestTools.TestFramework.Tests.TestCaseTests
 {
     public class FinallyExecutionTests
     {
+        [Fact]
+        public async Task NoExceptionsWhenAllBlocksAndFinallyBlocksPass()
+        {
+            // Arrange
+            TestCase tc = new TestBuilder()
+                .AddDependencyInstance(true)
+                .AddTestBlock<ExampleTestBlockWithBoolReturn>()
+                .AddFinallyBlock<ExampleFinallyBlock>(true)
+                .Build();
+
+            // Act
+            await tc.ExecuteAsync();
+
+            // Assert
+            Assert.True(tc.Passed, "Test case did not get marked as Passed when we expected it.");
+        }
 
         [Fact]
         public async Task FinallyBlockThrowsExpectedExceptionWhenNotOverridingDefaultFinallyBehavior()
@@ -79,6 +95,103 @@ namespace IntelliTect.TestTools.TestFramework.Tests.TestCaseTests
                 .AddDependencyInstance(false)
                 .AddTestBlock<ExampleTestBlockWithBoolReturn>()
                 .AddFinallyBlock<ExampleFinallyBlock>()
+                .Build();
+            tc.ThrowOnFinallyBlockException = false;
+
+            // Act
+            await Assert.ThrowsAsync<TestCaseException>(() => tc.ExecuteAsync());
+
+            // Assert
+            Assert.False(tc.Passed, "Test case did not get marked as Failed when we expected it.");
+        }
+
+        [Fact]
+        public async Task NoExceptionsWhenAllBlocksAndAsyncFinallyBlocksPass()
+        {
+            // Arrange
+            TestCase tc = new TestBuilder()
+                .AddDependencyInstance(true)
+                .AddTestBlock<ExampleTestBlockWithBoolReturn>()
+                .AddAsyncFinallyBlock<ExampleAsyncFinallyBlock>(true)
+                .Build();
+
+            // Act
+            await tc.ExecuteAsync();
+
+            // Assert
+            Assert.True(tc.Passed, "Test case did not get marked as Passed when we expected it.");
+        }
+
+        [Fact]
+        public async Task AsyncFinallyBlockThrowsExpectedExceptionWhenNotOverridingDefaultFinallyBehavior()
+        {
+            // Arrange
+            TestCase tc = new TestBuilder()
+                .AddDependencyInstance(true)
+                .AddTestBlock<ExampleTestBlockWithBoolReturn>()
+                .AddAsyncFinallyBlock<ExampleAsyncFinallyBlock>()
+                .Build();
+
+            // Act
+            var ex = await Assert.ThrowsAsync<AggregateException>(() => tc.ExecuteAsync());
+
+            // Assert
+            Assert.NotNull(ex.InnerExceptions);
+            Assert.Single(ex.InnerExceptions);
+            Assert.Contains("Test case succeeded",
+                ex.Message,
+                StringComparison.InvariantCultureIgnoreCase);
+            Assert.True(tc.Passed, "Test case did not get marked as Passed when we expected it.");
+        }
+
+        [Fact]
+        public async Task TestBlockAndAsyncFinallyBlockThrowsExpectedExceptionWhenNotOverridingDefaultFinallyBehavior()
+        {
+            // Arrange
+            TestCase tc = new TestBuilder()
+                .AddDependencyInstance(false)
+                .AddTestBlock<ExampleTestBlockWithBoolReturn>()
+                .AddAsyncFinallyBlock<ExampleAsyncFinallyBlock>()
+                .Build();
+
+            // Act
+            var ex = await Assert.ThrowsAsync<AggregateException>(() => tc.ExecuteAsync());
+
+            // Assert
+            Assert.NotNull(ex.InnerExceptions);
+            Assert.Equal(2, ex.InnerExceptions.Count);
+            Assert.Contains("Test case failed and finally blocks failed",
+                ex.Message,
+                StringComparison.InvariantCultureIgnoreCase);
+            Assert.False(tc.Passed, "Test case did not get marked as Failed when we expected it.");
+        }
+
+        [Fact]
+        public async Task AsyncFinallyBlockDoesNotThrowExceptionWhenOverridingDefaultFinallyBehavior()
+        {
+            // Arrange
+            TestCase tc = new TestBuilder()
+                .AddDependencyInstance(true)
+                .AddTestBlock<ExampleTestBlockWithBoolReturn>()
+                .AddAsyncFinallyBlock<ExampleAsyncFinallyBlock>()
+                .Build();
+            tc.ThrowOnFinallyBlockException = false;
+
+            // Act
+            await tc.ExecuteAsync();
+
+            // Assert
+            Assert.True(tc.Passed, "Test case did not get marked as Passed when we expected it.");
+        }
+
+        [Fact]
+        public async Task OnlyTestBlockThrowsExpectedExceptionWhenOverridingDefaultFinallyBehaviorWithAsyncFinallyBlock()
+        {
+            // Arrange
+            TestCase tc = new TestBuilder()
+                .AddDependencyInstance(false)
+                .AddTestBlock<ExampleTestBlockWithBoolReturn>()
+                .AddAsyncFinallyBlock<ExampleAsyncFinallyBlock>()
                 .Build();
             tc.ThrowOnFinallyBlockException = false;
 

--- a/IntelliTect.TestTools.TestFramework.Tests/TestData/Dependencies/SimulatorClasses.cs
+++ b/IntelliTect.TestTools.TestFramework.Tests/TestData/Dependencies/SimulatorClasses.cs
@@ -110,6 +110,15 @@ namespace IntelliTect.TestTools.TestFramework.Tests.TestData.Dependencies
         }
     }
 
+    public class ExampleAsyncFinallyBlock : TestBlock
+    {
+        public async Task Execute(bool result)
+        {
+            await Task.Delay(1);
+            Assert.True(result, "This is an expected failure.");
+        }
+    }
+
     public class ExampleAsyncBlockWithReturn : TestBlock
     {
         public async Task<bool> Execute()

--- a/IntelliTect.TestTools.TestFramework/TestBuilder.cs
+++ b/IntelliTect.TestTools.TestFramework/TestBuilder.cs
@@ -104,7 +104,7 @@ namespace IntelliTect.TestTools.TestFramework
             Block fb = CreateBlock<T>(testBlockArgs);
             fb.IsFinallyBlock = true;
             fb.IsAsync = true;
-            TestBlocks.Add(fb);
+            FinallyBlocks.Add(fb);
             return this;
         }
 


### PR DESCRIPTION
+ add unit tests for bug (and two unit tests for happy-path execution with both regular and async finally blocks)

## Description

Fix an bug where async finally blocks were tracked as test blocks, and so would never execute if an upstream block failed. Added tests for async finally blocks as they were missing (that was on me. oops 😞  )

### Ensure that your pull request has followed all the steps below:
- [x] Code compilation
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
