### PR TITLE
Changes to handling test passing and exceptions

### DIFF
--- a/IntelliTect.TestTools.TestFramework.Tests/TestCaseTests/FinallyExecutionTests.cs
+++ b/IntelliTect.TestTools.TestFramework.Tests/TestCaseTests/FinallyExecutionTests.cs
@@ -240,5 +240,24 @@ namespace IntelliTect.TestTools.TestFramework.Tests.TestCaseTests
             Assert.Equal(typeof(TrueException), exception.InnerExceptions[1].GetType());
             Assert.False(tc.Passed, "Test case was marked as Passed when we did not expected it.");
         }
+
+        [Fact]
+        public async Task CurrentFinallyBlockExceptionCountIncrementsWithEveryFailure()
+        {
+            // Arrange
+            TestCase tc = new TestBuilder()
+                .AddFinallyBlock<ExampleFinallyBlock>(false)
+                .AddFinallyBlock<ExampleFinallyBlock>(false)
+                .Build();
+            tc.ThrowOnFinallyBlockException = false;
+
+            // Act
+            await tc.ExecuteAsync();
+
+            // Assert
+            var test = tc.CurrentFinallyBlockExceptions;
+            Assert.Equal(2, tc.CurrentFinallyBlockExceptions.Count);
+            Assert.True(tc.Passed, "Test case did not get marked as Passed when we expected it.");
+        }
     }
 }

--- a/IntelliTect.TestTools.TestFramework.Tests/TestCaseTests/FinallyExecutionTests.cs
+++ b/IntelliTect.TestTools.TestFramework.Tests/TestCaseTests/FinallyExecutionTests.cs
@@ -3,6 +3,7 @@ using IntelliTect.TestTools.TestFramework.Tests.TestData.TestBlocks;
 using System;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Sdk;
 
 namespace IntelliTect.TestTools.TestFramework.Tests.TestCaseTests
 {
@@ -200,6 +201,44 @@ namespace IntelliTect.TestTools.TestFramework.Tests.TestCaseTests
 
             // Assert
             Assert.False(tc.Passed, "Test case did not get marked as Failed when we expected it.");
+        }
+
+        [Fact]
+        public async Task TestCasePassedIsSetTrueBeforeFinallyBlocksRun()
+        {
+            // Arrange
+            TestCase tc = new TestBuilder()
+                .AddDependencyInstance(true)
+                .AddTestBlock<ExampleTestBlockWithBoolReturn>()
+                .AddFinallyBlock<ExampleBlockCheckingTestSuccess>()
+                .Build();
+
+            // Act
+            await tc.ExecuteAsync();
+
+            // Assert
+            Assert.True(tc.Passed, "Test case did not get marked as Passed when we expected it.");
+        }
+
+        [Fact]
+        public async Task TestCasePassedIsSetTrueEvenIfFinallyBlockFails()
+        {
+            // Arrange
+            TestCase tc = new TestBuilder()
+                .AddDependencyInstance(false)
+                .AddTestBlock<ExampleTestBlockWithBoolReturn>()
+                .AddFinallyBlock<ExampleBlockCheckingTestSuccess>()
+                .Build();
+
+            // Act
+            AggregateException exception = await Assert.ThrowsAsync<AggregateException>(() => tc.ExecuteAsync());
+
+            // Assert
+            Assert.Equal(2, exception.InnerExceptions.Count);
+            Assert.Equal(typeof(DivideByZeroException), exception.InnerException?.GetType());
+            Assert.Equal(typeof(DivideByZeroException), exception.InnerExceptions[0].GetType());
+            Assert.Equal(typeof(TrueException), exception.InnerExceptions[1].GetType());
+            Assert.False(tc.Passed, "Test case was marked as Passed when we did not expected it.");
         }
     }
 }

--- a/IntelliTect.TestTools.TestFramework.Tests/TestData/Dependencies/SimulatorClasses.cs
+++ b/IntelliTect.TestTools.TestFramework.Tests/TestData/Dependencies/SimulatorClasses.cs
@@ -134,4 +134,12 @@ namespace IntelliTect.TestTools.TestFramework.Tests.TestData.Dependencies
             await Task.Delay(1);
         }
     }
+
+    public class ExampleBlockCheckingTestSuccess : TestBlock
+    {
+        public void Execute(TestCase tc)
+        {
+            Assert.True(tc.Passed);
+        }
+    }
 }

--- a/IntelliTect.TestTools.TestFramework/TestCase.cs
+++ b/IntelliTect.TestTools.TestFramework/TestCase.cs
@@ -114,6 +114,16 @@ namespace IntelliTect.TestTools.TestFramework
                     }
                 }
 
+                if (TestBlockException is null)
+                {
+                    Passed = true;
+                    Log?.Info("Test case finished successfully.");
+                }
+                else
+                {
+                    Log?.Critical($"Test case failed and will continue to executing Finally blocks. Exception: {TestBlockException}");
+                }
+
                 foreach (var fb in FinallyBlocks)
                 {
                     if (Log is not null) Log.CurrentTestBlock = fb.Type.ToString();
@@ -128,20 +138,6 @@ namespace IntelliTect.TestTools.TestFramework
                     {
                         Log?.Critical($"Finally block failed: {FinallyBlockExceptions.LastOrDefault()}");
                     }
-                }
-
-                if (TestBlockException is null)
-                {
-                    // Note: This likely needs to be moved up above the finally blocks.
-                    // If a test case "passes" i.e. finishes all of its test blocks, we probably need to know that
-                    //  in the finally blocks.
-                    // Need to think about how to handle "passed" state if a finally block fails.
-                    Passed = true;
-                    Log?.Info("Test case finished successfully.");
-                }
-                else
-                {
-                    Log?.Critical($"Test case failed: {TestBlockException}");
                 }
             }
 

--- a/IntelliTect.TestTools.TestFramework/TestCase.cs
+++ b/IntelliTect.TestTools.TestFramework/TestCase.cs
@@ -47,7 +47,8 @@ namespace IntelliTect.TestTools.TestFramework
         /// <remarks>This collection contains all exceptions that occurred in finally blocks, allowing
         /// callers to inspect or handle them after execution. The list is empty if no exceptions were thrown in any
         /// finally block.</remarks>
-        public List<Exception> FinallyBlockExceptions { get; } = [];
+        //public readonly List<Exception> FinallBlockExceptions { get; } = [];
+        public IReadOnlyList<Exception> CurrentFinallyBlockExceptions => FinallyBlockExceptions;
         /// <summary>
         /// Did the test case pass? This is determined by whether any test block threw an exception.
         /// </summary>
@@ -66,6 +67,7 @@ namespace IntelliTect.TestTools.TestFramework
         private ITestCaseLogger? Log { get; set; }
         private IServiceCollection ServiceCollection { get; }
         private Dictionary<Type, object> BlockOutput { get; } = [];
+        private List<Exception> FinallyBlockExceptions { get; } = [];
 
         /// <summary>
         /// Legacy method signature. Executes the test case. NOTE: Prefer to use ExecuteAsync, even if you have no awaitable test blocks.

--- a/IntelliTect.TestTools.TestFramework/TestCase.cs
+++ b/IntelliTect.TestTools.TestFramework/TestCase.cs
@@ -37,22 +37,35 @@ namespace IntelliTect.TestTools.TestFramework
         /// If a finally block fails and this property is true, the test case is still considered passed internally, but most unit test frameworks will mark the test failed.
         /// </summary>
         public bool ThrowOnFinallyBlockException { get; set; } = true;
+        /// <summary>
+        /// If any test block throws an exception, it will be stored here. Finally block exceptions are stored separately in FinallyBlockExceptions. If this is not null at the end of the test case execution, the test case is considered failed.
+        /// </summary>
+        public Exception? TestBlockException { get; private set; }
+        /// <summary>
+        /// Gets the list of exceptions that were thrown during the execution of finally blocks.
+        /// </summary>
+        /// <remarks>This collection contains all exceptions that occurred in finally blocks, allowing
+        /// callers to inspect or handle them after execution. The list is empty if no exceptions were thrown in any
+        /// finally block.</remarks>
+        public List<Exception> FinallyBlockExceptions { get; } = [];
+        /// <summary>
+        /// Did the test case pass? This is determined by whether any test block threw an exception.
+        /// </summary>
+        /// <remarks>
+        /// Finally block exceptions do not cause the test case to be marked as failed, but they are still captured and can cause the test case to throw after execution if ThrowOnFinallyBlockException is true.
+        /// </remarks>
+        public bool Passed { get; set; }
 
         // May make sense to make some of the below public if it's needed for debugging.
         // If so, definitely need to change them to internal or private sets.
 
-        internal List<Block> TestBlocks { get; set; } = new();
-        internal List<Block> FinallyBlocks { get; set; } = new();
+        internal List<Block> TestBlocks { get; set; } = [];
+        internal List<Block> FinallyBlocks { get; set; } = [];
         internal bool HasLogger { get; set; } = true;
 
         private ITestCaseLogger? Log { get; set; }
         private IServiceCollection ServiceCollection { get; }
-        private Dictionary<Type, object> BlockOutput { get; } = new();
-        private Exception? TestBlockException { get; set; }
-        private List<Exception> FinallyBlockExceptions { get; } = new();
-
-        // Has this test case passed? Will only be true if every regular test block succeeds.
-        public bool Passed { get; set; }
+        private Dictionary<Type, object> BlockOutput { get; } = [];
 
         /// <summary>
         /// Legacy method signature. Executes the test case. NOTE: Prefer to use ExecuteAsync, even if you have no awaitable test blocks.


### PR DESCRIPTION
## Description

- Immediately mark the test as passed if no test blocks throw an exception
- Expose the TestBlockException get and FinallyBlockExceptions so blocks can act based off of the caught exceptions

### Ensure that your pull request has followed all the steps below:
- [x] Code compilation
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
